### PR TITLE
feat(sales): Modelo, factory, seeder, resource, policy e controller de Sales

### DIFF
--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Sale;
+use Illuminate\Http\Request;
+use App\Http\Resources\SaleResource;
+
+class SaleController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Sale::class, 'sale');
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return SaleResource::collection(Sale::all());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'products' => 'required|array',
+            'products.*.id' => 'required|exists:products,id',
+            'products.*.quantity' => 'required|integer|min:1',
+        ]);
+
+        /** @var \App\Models\User */
+        $user = auth()->user();
+        $sale = $user->sales()->create();
+
+        foreach ($validated['products'] as $product) {
+            $sale->products()->attach($product['id'], ['quantity' => $product['quantity']]);
+        }
+
+        return SaleResource::make($sale);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Sale $sale)
+    {
+        return SaleResource::make($sale);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Sale $sale)
+    {
+        $validated = $request->validate([
+            'products' => 'required|array',
+            'products.*.id' => 'required|exists:products,id',
+            'products.*.quantity' => 'required|integer|min:1',
+        ]);
+
+        foreach ($validated['products'] as $product) {
+            $sale->products()->attach($product['id'], ['quantity' => $product['quantity']]);
+        }
+
+        return SaleResource::make($sale);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Sale $sale)
+    {
+        $sale->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Resources/SaleResource.php
+++ b/app/Http/Resources/SaleResource.php
@@ -5,7 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class ProductResource extends JsonResource
+class SaleResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -16,12 +16,10 @@ class ProductResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'name' => $this->name,
-            'price' => $this->price,
-            'description' => $this->description,
-            'quantity' => $this->whenPivotLoaded('product_sale', function () {
-                return $this->pivot->quantity;
-            }),
+            'amount' => $this->total(),
+            'products' => ProductResource::collection($this->whenLoaded('products')),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -5,7 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class ProductResource extends JsonResource
+class UserResource extends JsonResource
 {
     /**
      * Transform the resource into an array.
@@ -17,11 +17,7 @@ class ProductResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'price' => $this->price,
-            'description' => $this->description,
-            'quantity' => $this->whenPivotLoaded('product_sale', function () {
-                return $this->pivot->quantity;
-            }),
+            'email' => $this->email,
         ];
     }
 }

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Sale extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * The products that belong to the sale.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function products(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class)->withPivot('quantity');
+    }
+
+    /**
+     * Get the user that owns the sale.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the total amount of the sale.
+     */
+    public function total(): float
+    {
+        $sum = 0;
+        foreach ($this->products as $product) {
+            $sum += ($product->price * $product->pivot->quantity);
+        }
+
+        return $sum;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,15 +2,16 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens;
     use HasFactory;
@@ -58,4 +59,14 @@ class User extends Authenticatable
     protected $appends = [
         'profile_photo_url',
     ];
+
+    /**
+     * Get the sales for the user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function sales(): HasMany
+    {
+        return $this->hasMany(Sale::class);
+    }
 }

--- a/app/Policies/SalePolicy.php
+++ b/app/Policies/SalePolicy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Sale;
+use App\Models\User;
+
+class SalePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Sale $sale): bool
+    {
+        return $user->id === $sale->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Sale $sale): bool
+    {
+        return $user->id === $sale->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Sale $sale): bool
+    {
+        return $user->id === $sale->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Sale $sale): bool
+    {
+        return $user->id === $sale->user_id;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Sale $sale): bool
+    {
+        return $user->id === $sale->user_id;
+    }
+}

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TeamPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Team $team): bool
+    {
+        return $user->belongsToTeam($team);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can add team members.
+     */
+    public function addTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can update team member permissions.
+     */
+    public function updateTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can remove team members.
+     */
+    public function removeTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+}

--- a/database/factories/SaleFactory.php
+++ b/database/factories/SaleFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Sale>
+ */
+class SaleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+        ];
+    }
+}

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Team>
+ */
+class TeamFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->company(),
+            'user_id' => User::factory(),
+            'personal_team' => true,
+        ];
+    }
+}

--- a/database/migrations/2024_02_29_162523_create_sales_table.php
+++ b/database/migrations/2024_02_29_162523_create_sales_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sales', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(\App\Models\User::class)->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sales');
+    }
+};

--- a/database/migrations/2024_02_29_182034_create_sale_records_table.php
+++ b/database/migrations/2024_02_29_182034_create_sale_records_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('product_sale', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(\App\Models\Sale::class)->constrained()->onDelete('cascade');
+            $table->foreignIdFor(\App\Models\Product::class)->constrained()->onDelete('cascade');
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_records');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         if (!app()->environment('production')) {
-            \App\Models\User::factory()->create([
+            $user = \App\Models\User::factory()->create([
                 'name' => 'Developer User',
                 'email' => 'dev@abc.com',
             ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\SaleController;
 
 /*
 |--------------------------------------------------------------------------
@@ -21,3 +22,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::get('/products', [ProductController::class, 'index']);
 Route::get('/products/{product}', [ProductController::class, 'show']);
+
+Route::resource('sales', SaleController::class)
+    ->only(['index', 'store', 'show', 'update', 'destroy'])
+    ->middleware('auth:sanctum');

--- a/tests/Feature/SaleTest.php
+++ b/tests/Feature/SaleTest.php
@@ -1,0 +1,284 @@
+<?php
+
+use App\Models\Sale;
+use App\Models\Product;
+use App\Models\User;
+
+// Golden path
+test('Get all sales', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $products = Product::factory(6)->create();
+    $sales = Sale::factory(3)->create();
+
+    $sales->each(function ($sale) use ($products) {
+        $sale->products()->attach($products->random()->id, ['quantity' => 1]);
+    });
+
+    $this->getJson('/api/sales')
+        ->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'amount',
+                    'products' => [
+                        '*' => [
+                            'id',
+                            'name',
+                            'price',
+                            'description',
+                            'quantity'
+                        ],
+                    ],
+                    'created_at',
+                    'updated_at',
+                ],
+            ],
+        ])
+        ->assertJsonCount(3, 'data');
+});
+
+test('Get a sale by id', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $products = Product::factory(2)->create();
+    $sale = Sale::factory()->recycle($user)->create();
+
+    $sale->products()->attach($products->random()->id, ['quantity' => 1]);
+
+    $this->getJson('/api/sales/' . $sale->id)
+        ->assertOk()
+        ->assertJson([
+            'data' => [
+                'id' => $sale->id,
+                'amount' => $sale->total(),
+                'products' => [
+                    0 => [
+                        'id' => $sale->products->first()->id,
+                        'name' => $sale->products->first()->name,
+                        'price' => $sale->products->first()->price,
+                        'description' => $sale->products->first()->description,
+                        'quantity' => 1
+                    ]
+                ],
+                'created_at' => $sale->created_at->toISOString(),
+                'updated_at' => $sale->updated_at->toISOString(),
+            ],
+        ]);
+});
+
+test('Create a sale', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $products = Product::factory(2)->create();
+
+    $this->postJson('/api/sales', [
+        'products' => [
+            ['id' => $products->first()->id, 'quantity' => 1],
+            ['id' => $products->last()->id, 'quantity' => 1],
+        ],
+    ])
+        ->assertCreated()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'amount',
+                'products' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'price',
+                        'description',
+                        'quantity'
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+});
+
+test('Add more products to a sale', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $products = Product::factory(3)->create();
+    $sale = Sale::factory()->recycle($user)->create();
+    $sale->products()->attach($products->first()->id, ['quantity' => 1]);
+
+    $this->putJson('/api/sales/' . $sale->id, [
+        'products' => [
+            ['id' => $products->get(2)->id, 'quantity' => 1],
+            ['id' => $products->last()->id, 'quantity' => 1],
+        ],
+    ])
+        ->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'amount',
+                'products' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'price',
+                        'description',
+                        'quantity'
+                    ],
+                ],
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+});
+
+test('Cancel a sale', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $sale = Sale::factory()->recycle($user)->create();
+
+    $this->deleteJson('/api/sales/' . $sale->id)
+        ->assertNoContent();
+
+    $this->assertSoftDeleted('sales', ['id' => $sale->id]);
+});
+
+// Sad path - Validation
+test('Create a sale with invalid data', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    Product::factory(3)->create();
+    $this->postJson('/api/sales', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors([
+            'products'
+        ]);
+})->with([
+    'products' => [
+        'string',
+        1,
+        true,
+        false,
+        null,
+        ['id' => -1, 'quantity' => 1],
+        ['id' => 1, 'quantity' => 0],
+    ],
+]);
+
+test('Add more products to a sale with invalid data', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $products = Product::factory(3)->create();
+    $sale = Sale::factory()->recycle($user)->create();
+    $sale->products()->attach($products->first()->id, ['quantity' => 1]);
+
+    $this->putJson('/api/sales/' . $sale->id, [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors([
+            'products'
+        ]);
+})->with([
+    'products' => [
+        'string',
+        1,
+        true,
+        false,
+        null,
+        ['id' => 1, 'quantity' => 0],
+        ['id' => -1, 'quantity' => 1],
+    ],
+]);
+
+// Sad path - Authorization
+test('Get all sales without being authenticated', function () {
+    $this->getJson('/api/sales')
+        ->assertUnauthorized();
+});
+
+test('Get a sale by id without being authenticated', function () {
+    $sale = Sale::factory()->create();
+
+    $this->getJson('/api/sales/' . $sale->id)
+        ->assertUnauthorized();
+});
+
+test('Create a sale without being authenticated', function () {
+    $this->postJson('/api/sales', [])
+        ->assertUnauthorized();
+});
+
+test('Add more products to a sale without being authenticated', function () {
+    $sale = Sale::factory()->create();
+
+    $this->putJson('/api/sales/' . $sale->id, [])
+        ->assertUnauthorized();
+});
+
+test('Cancel a sale without being authenticated', function () {
+    $sale = Sale::factory()->create();
+
+    $this->deleteJson('/api/sales/' . $sale->id)
+        ->assertUnauthorized();
+});
+
+test('Get a sale by id from another user', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $sale = Sale::factory()->create();
+
+    $this->getJson('/api/sales/' . $sale->id)
+        ->assertForbidden();
+});
+
+test('Add more products to a sale from another user', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $sale = Sale::factory()->create();
+
+    $this->putJson('/api/sales/' . $sale->id, [])
+        ->assertForbidden();
+});
+
+test('Cancel a sale from another user', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $sale = Sale::factory()->create();
+
+    $this->deleteJson('/api/sales/' . $sale->id)
+        ->assertForbidden();
+});
+
+// Sad path - Not found
+test('Get a sale by id that does not exist', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->getJson('/api/sales/1')
+        ->assertNotFound();
+});
+
+test('Add more products to a sale that does not exist', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->putJson('/api/sales/1', [])
+        ->assertNotFound();
+});
+
+test('Cancel a sale that does not exist', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $this->deleteJson('/api/sales/1')
+        ->assertNotFound();
+});
+
+// Sad path - Conflict
+test('Cancel a sale that is already canceled', function () {
+    $this->actingAs($user = User::factory()->create());
+
+    $sale = Sale::factory()->recycle($user)->create();
+
+    $this->deleteJson('/api/sales/' . $sale->id)
+        ->assertNoContent();
+
+    $this->deleteJson('/api/sales/' . $sale->id)
+        ->assertNotFound();
+});


### PR DESCRIPTION
Adiciona modelo, factory, seeder, resource, policy e controller de Sales com relacionamento many-to-many

- Implementado modelo, factory, seeder, resource, policy e controller de Sales
- Criados testes utilizando TDD para as seguintes funcionalidades:
  - Obter todas as vendas
  - Obter uma venda por ID
  - Criar uma venda
  - Adicionar mais produtos a uma venda
  - Cancelar uma venda
  - Tratamento de casos de uso inválidos
  - Verificação de autenticação em endpoints
  - Verificação de autorização para operações de usuário em vendas
  - Tratamento de casos de vendas que não existem ou já foram canceladas